### PR TITLE
Replace green with indigo

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       property="og:description"
     />
     <meta
-      content="https://s3.amazonaws.com/freecodecamp/curriculum-diagram-full.jpg"
+      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
       property="og:image"
     />
     <meta content="article" property="og:type" />
@@ -45,7 +45,7 @@
     <meta content="@freecodecamp" name="twitter:site" />
     <meta content="summary_large_image" name="twitter:card" />
     <meta
-      content="https://s3.amazonaws.com/freecodecamp/curriculum-diagram-full.jpg"
+      content="https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png"
       name="twitter:image:src"
     />
     <meta content="Learn to code and help nonprofits" name="twitter:title" />
@@ -57,138 +57,138 @@
     <meta content="#FFFFFF" name="msapplication-TileColor" />
     <meta content="/" name="msapplication-TileImage" />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-144x144.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="144x144"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-192x192.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-384x384.png"
       rel="android-chrome"
-      sizes="192x192"
+      sizes="384x384"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-36x36.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="36x36"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-48x48.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="48x48"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-72x72.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="72x72"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-96x96.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
       sizes="96x96"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/android-chrome-manifest.json"
+      href="https://cdn.freecodecamp.org/universal/favicons/site.webmanifest"
       rel="android-chrome-manifest"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-114x114.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="114x114"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-120x120.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="120x120"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-144x144.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="144x144"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-152x152.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="152x152"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-180x180.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="180x180"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-57x57.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="57x57"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-60x60.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="60x60"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-72x72.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="72x72"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-76x76.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="76x76"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon-precomposed.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon-precomposed"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/apple-touch-icon.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-16x16.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-16x16.png"
       rel="favicon"
       sizes="16x16"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-32x32.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
       rel="favicon"
       sizes="32x32"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon-96x96.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
       rel="favicon"
       sizes="96x96"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-144x144.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
       rel="mstile"
       sizes="144x144"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-150x150.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
       rel="mstile"
       sizes="150x150"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-310x310.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
       rel="mstile"
       sizes="310x310"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-310x150.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
       rel="mstile"
       sizes="310x150"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/mstile-70x70.png"
+      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
       rel="mstile"
       sizes="70x70"
     />
     <link
-      href="https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
       rel="favicon"
     />
     <link
-      href="//s3.amazonaws.com/freecodecamp/favicons/favicon.ico"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
       rel="shortcut icon"
     />
     <link rel="stylesheet" href="css/style.css" />

--- a/index.html
+++ b/index.html
@@ -55,11 +55,14 @@
     />
     <meta content="a40ee5d5dba3bb091ad783ebd2b1383f" name="p:domain_verify" />
     <meta content="#FFFFFF" name="msapplication-TileColor" />
-    <meta content="/" name="msapplication-TileImage" />
+    <meta
+      content="https://cdn.freecodecamp.org/universal/favicons/browserconfig.xml"
+      rel="msapplication-config"
+    />
     <link
       href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
       rel="android-chrome"
-      sizes="144x144"
+      sizes="192x192"
     />
     <link
       href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-384x384.png"
@@ -67,81 +70,13 @@
       sizes="384x384"
     />
     <link
-      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
-      rel="android-chrome"
-      sizes="36x36"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
-      rel="android-chrome"
-      sizes="48x48"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
-      rel="android-chrome"
-      sizes="72x72"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/android-chrome-192x192.png"
-      rel="android-chrome"
-      sizes="96x96"
-    />
-    <link
       href="https://cdn.freecodecamp.org/universal/favicons/site.webmanifest"
-      rel="android-chrome-manifest"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="114x114"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="120x120"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="144x144"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="152x152"
+      rel="manifest"
     />
     <link
       href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
       rel="apple-touch-icon"
       sizes="180x180"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="57x57"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="60x60"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="72x72"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
-      sizes="76x76"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon-precomposed"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/apple-touch-icon.png"
-      rel="apple-touch-icon"
     />
     <link
       href="https://cdn.freecodecamp.org/universal/favicons/favicon-16x16.png"
@@ -158,39 +93,6 @@
       rel="favicon"
       sizes="96x96"
     />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="144x144"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="150x150"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="310x310"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="310x150"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/mstile-150x150.png"
-      rel="mstile"
-      sizes="70x70"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
-      rel="favicon"
-    />
-    <link
-      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
-      rel="shortcut icon"
-    />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/grid.css" />
     <link
@@ -198,11 +100,11 @@
       rel="stylesheet"
     />
     <script>
-      (function(i, s, o, g, r, a, m) {
+      (function (i, s, o, g, r, a, m) {
         i["GoogleAnalyticsObject"] = r;
         (i[r] =
           i[r] ||
-          function() {
+          function () {
             (i[r].q = i[r].q || []).push(arguments);
           }),
           (i[r].l = 1 * new Date());
@@ -261,9 +163,7 @@
               We couple this "command line chic" aesthetic with large fonts,
               high-contrast layouts, and explicit buttons and links.
             </p>
-            <p>
-              Here are some examples:
-            </p>
+            <p>Here are some examples:</p>
             <div class="twelve columns alpha">
               <div class=""><img src="img/screen-shot-3.png" /></div>
               <br />
@@ -283,7 +183,7 @@
         </div>
         <div class="row clearfix pad">
           <div class="eight columns alpha">
-            <div class="logo-border ">
+            <div class="logo-border">
               <img src="img/fcc_primary_large.svg" />
             </div>
             <div class="palette-pad">
@@ -300,7 +200,7 @@
             </div>
           </div>
           <div class="four columns omega">
-            <div class="logo-border-glyph ">
+            <div class="logo-border-glyph">
               <img src="img/fcc_primary_small.svg" />
             </div>
             <div class="palette-pad">
@@ -328,7 +228,7 @@
           </p>
 
           <div class="row clearfix">
-            <div class="eight columns alpha ">
+            <div class="eight columns alpha">
               <div class="logo-border white">
                 <img src="img/fcc_secondary_large.svg" />
               </div>
@@ -525,7 +425,7 @@
           <div class="row clearfix center">
             <h3>Secondary Colors</h3>
             <div class="three columns alpha">
-              <div class="color-palette dark-purple "></div>
+              <div class="color-palette dark-purple"></div>
               <div class="palette-pad">
                 <h4>Dark Purple</h4>
                 <p>#5a01a7</p>
@@ -588,29 +488,29 @@
           </div>
           <div class="row clearfix">
             <div class="four columns alpha">
-              <div class="misuse-border "><img src="img/misuse-1.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-1.png" /></div>
               <h6 class="center">Do not rotate or distort logo</h6>
             </div>
             <div class="four columns">
-              <div class="misuse-border "><img src="img/misuse-2.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-2.png" /></div>
               <h6 class="center">Do not reassign colors</h6>
             </div>
             <div class="four columns omega">
-              <div class="misuse-border "><img src="img/misuse-3.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-3.png" /></div>
               <h6 class="center">Do not rearrange logo elements</h6>
             </div>
           </div>
           <div class="row clearfix">
             <div class="four columns alpha">
-              <div class="misuse-border "><img src="img/misuse-4.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-4.png" /></div>
               <h6 class="center">Do not scale elements seperately</h6>
             </div>
             <div class="four columns">
-              <div class="misuse-border "><img src="img/misuse-5.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-5.png" /></div>
               <h6 class="center">Do not enclose in shapes</h6>
             </div>
             <div class="four columns omega">
-              <div class="misuse-border "><img src="img/misuse-6.png" /></div>
+              <div class="misuse-border"><img src="img/misuse-6.png" /></div>
               <h6 class="center">Do not add elements to logo</h6>
             </div>
           </div>
@@ -632,22 +532,20 @@
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 
     <script>
-      $(".hidden-code").click(function(e) {
+      $(".hidden-code").click(function (e) {
         e.preventDefault();
-        $(this)
-          .children(".gist")
-          .slideToggle();
+        $(this).children(".gist").slideToggle();
       });
 
       var originalText;
       $(".example-grid")
         .children()
         .hover(
-          function() {
+          function () {
             originalText = $(this).text();
             $(this).html($(this).width() + "px");
           },
-          function() {
+          function () {
             $(this).html(originalText);
           }
         );


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Replaces the green images (hosted on Amazon) with the indigo images from our CDN.

Not all of the sizes that were present are available on the CDN, so I used the ones I could - if those particular `meta` tags should be removed instead feel free to let me know!

Closes #40 

Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/38540