### PR TITLE
fix: Use correct favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,8 @@
       sizes="32x32"
     />
     <link
-      href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png"
-      rel="favicon"
-      sizes="96x96"
+      href="https://cdn.freecodecamp.org/universal/favicons/favicon.ico"
+      rel="icon"
     />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/grid.css" />


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

@ahmadabdolsaheb I made the same error here with missing the base favicon link. This should correct the issue 🙂 