### PR TITLE
fix(a11y): improved focus visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,6 @@ h6 { font-size: 18px; line-height: 21px; font-family: 'Hack', monospace;}
 
 a, a:visited { color:#d0d0d5;
   text-decoration: underline;
-  outline: 0;
   font-size: inherit;
 }
 a:hover, a:focus { color: white; text-decoration: none;}
@@ -196,4 +195,9 @@ nav ul li a:focus {
   border-radius: 100px;
   margin: auto;
   margin-top: 10px;
+}
+
+*:focus-visible {
+  outline: 3px solid #198eee;
+  outline-offset: 0;
 }


### PR DESCRIPTION
Checklist:
- [x] I have read and followed [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)
- [x] My pull request targets the main branch (of the design style guide in this case)
- [x] I have tested these changes either locally on my machine, or GitPod.

Closes #47

UI Screenshots (Chrome)
![image](https://github.com/freeCodeCamp/design-style-guide/assets/125262707/ecb48ea6-550c-4040-ba84-e88c02958729)
![image](https://github.com/freeCodeCamp/design-style-guide/assets/125262707/5739398e-a032-4f9a-99ab-9f29d8de7c18)
![image](https://github.com/freeCodeCamp/design-style-guide/assets/125262707/43a99ab5-d2fa-43f6-97be-d98a1b6a9ab9)

<!-- Feel free to add any additional description of changes below this line -->
- Removed `outline:0 ` from the links 
- Added focus-visible to all elements
- Used the same focus style and colour as the main page
- Tested the changes in Chrome, Edge, Firefox, Brave, Opera and Safari
